### PR TITLE
[fix] - 'win' in RuntimeId.props

### DIFF
--- a/src/DlibDotNet/DlibDotNet.csproj
+++ b/src/DlibDotNet/DlibDotNet.csproj
@@ -29,7 +29,6 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <Optimize>true</Optimize>
-    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
     <DocumentationFile>docs\DlibDotNet.xml</DocumentationFile>
   </PropertyGroup>
 

--- a/src/DlibDotNet/RuntimeId.props
+++ b/src/DlibDotNet/RuntimeId.props
@@ -4,7 +4,7 @@
     <DefaultOSGroup Condition="'$(OS)'=='Unix' AND Exists('/Applications')">osx</DefaultOSGroup>
     <DefaultOSGroup Condition="'$(DefaultOSGroup)'=='' AND '$(OS)'=='Unix' AND $([MSBuild]::IsOSPlatform('FREEBSD'))">linux</DefaultOSGroup>
     <DefaultOSGroup Condition="'$(DefaultOSGroup)'=='' AND '$(OS)'=='Unix' AND $([MSBuild]::IsOSPlatform('NETBSD'))">linux</DefaultOSGroup>
-    <DefaultOSGroup Condition="'$(DefaultOSGroup)'=='' AND '$(OS)'=='Windows_NT' AND $([MSBuild]::IsOSPlatform('Windows'))">windows</DefaultOSGroup>
+    <DefaultOSGroup Condition="'$(DefaultOSGroup)'=='' AND '$(OS)'=='Windows_NT' AND $([MSBuild]::IsOSPlatform('Windows'))">win</DefaultOSGroup>
     <DefaultOSGroup Condition="'$(DefaultOSGroup)'=='' AND '$(OS)'=='Unix'">linux</DefaultOSGroup>
     <DefaultOSGroup Condition="'$(DefaultOSGroup)'==''">win</DefaultOSGroup>
   </PropertyGroup>

--- a/src/DlibDotNet/docs/DlibDotNet.xml
+++ b/src/DlibDotNet/docs/DlibDotNet.xml
@@ -4,6 +4,26 @@
         <name>DlibDotNet</name>
     </assembly>
     <members>
+        <member name="M:DlibDotNet.Array2D`1.DisposeUnmanaged">
+            <summary>
+            Releases all unmanaged resources.
+            </summary>
+        </member>
+        <member name="M:DlibDotNet.Array2D`1.Row`1.DisposeUnmanaged">
+            <summary>
+            Releases all unmanaged resources.
+            </summary>
+        </member>
+        <member name="M:DlibDotNet.Array2DMatrix`1.DisposeUnmanaged">
+            <summary>
+            Releases all unmanaged resources.
+            </summary>
+        </member>
+        <member name="M:DlibDotNet.Array2DMatrix`1.Row`1.DisposeUnmanaged">
+            <summary>
+            Releases all unmanaged resources.
+            </summary>
+        </member>
         <member name="T:DlibDotNet.Array`1">
             <summary>
             This object represents a 1-Dimensional array of objects. 
@@ -37,26 +57,6 @@
             Returns an enumerator that iterates through a collection.
             </summary>
             <returns>An <see cref="T:System.Collections.IEnumerator"/> object that can be used to iterate through the collection.</returns>
-        </member>
-        <member name="M:DlibDotNet.Array2D`1.DisposeUnmanaged">
-            <summary>
-            Releases all unmanaged resources.
-            </summary>
-        </member>
-        <member name="M:DlibDotNet.Array2D`1.Row`1.DisposeUnmanaged">
-            <summary>
-            Releases all unmanaged resources.
-            </summary>
-        </member>
-        <member name="M:DlibDotNet.Array2DMatrix`1.DisposeUnmanaged">
-            <summary>
-            Releases all unmanaged resources.
-            </summary>
-        </member>
-        <member name="M:DlibDotNet.Array2DMatrix`1.Row`1.DisposeUnmanaged">
-            <summary>
-            Releases all unmanaged resources.
-            </summary>
         </member>
         <member name="T:DlibDotNet.Dlib">
             <summary>


### PR DESCRIPTION
PlatformId.props should have "win" instead of "windows"
```
 <DefaultOSGroup Condition="'$(DefaultOSGroup)'=='' AND '$(OS)'=='Windows_NT' AND $([MSBuild]::IsOSPlatform('Windows'))">win</DefaultOSGroup>
```