### PR TITLE
[fix] - no tests for netcoreapp3.0 targets for DlibDotNet.Native.Test…

### DIFF
--- a/test/DlibDotNet.Native.Tests/PackageReference.csproj
+++ b/test/DlibDotNet.Native.Tests/PackageReference.csproj
@@ -7,7 +7,7 @@
    </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'==''">
-    <TargetFrameworks Condition="$(OS.EndsWith('NT'))">net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS.EndsWith('NT'))">net461;netcoreapp2.1</TargetFrameworks>
     <TargetFramework Condition="$(OS.EndsWith('NT'))">net461</TargetFramework>
     <TargetFramework Condition="$(OS.EndsWith('Unix'))">netcoreapp2.0</TargetFramework>
   </PropertyGroup>

--- a/test/DlibDotNet.Native.Tests/Restore.bat
+++ b/test/DlibDotNet.Native.Tests/Restore.bat
@@ -2,6 +2,9 @@ rd %USERPROFILE%\.nuget\packages\dlibdotnet\ /Q /S
 rd %USERPROFILE%\.nuget\packages\dlibdotnet.native\ /Q /S
 rem nuget config -set repositoryPath=%USERPROFILE%\.nuget -configfile nuget.config
 rem dotnet add PackageReference.csproj package "DlibDotNet" -f net461 -s %USERPROFILE%\.nuget\
-dotnet add package DlibDotNet --version 19.16.99.20190105-rc1 -f netcoreapp3.0 --source https://www.myget.org/F/nuget-dotnet/api/v3/index.json
 
-dotnet build -c Release -f netcoreapp3.0 -r win-x64
+dotnet add package DlibDotNet --version 19.16.99.20190105-rc1 -f netcoreapp2.1 --source https://www.myget.org/F/nuget-dotnet/api/v3/index.json
+dotnet build -c Release -f netcoreapp2.1 -r win-x64
+
+dotnet add package DlibDotNet --version 19.16.99.20190105-rc1 -f net461 --source https://www.myget.org/F/nuget-dotnet/api/v3/index.json
+dotnet build -c Release -f net461 -r win-x64


### PR DESCRIPTION
- removed netcoreapp3.0 targets 
- dlibdotnet depends on dlibdotnet.native package, and nuget should fetch it automatically...
- try to clean nuget cache with:
  `dotnet nuget locals all -l`
  `dotnet nuget locals all --clean`

 
 