### PR TITLE
[fix] Null terminate all strings passed to native code

### DIFF
--- a/src/DlibDotNet/DataIO/ImageDatasetMetadata/Box.cs
+++ b/src/DlibDotNet/DataIO/ImageDatasetMetadata/Box.cs
@@ -140,6 +140,9 @@ namespace DlibDotNet.ImageDatasetMetadata
             {
                 this.ThrowIfDisposed();
                 var str = Dlib.Encoding.GetBytes(value ?? "");
+                var strLength = str.Length;
+                Array.Resize(ref str, strLength + 1);
+                str[strLength] = (byte)'\0';
                 NativeMethods.image_dataset_metadata_box_set_label(this.NativePtr, str);
             }
         }
@@ -272,6 +275,9 @@ namespace DlibDotNet.ImageDatasetMetadata
                     this.Parent.ThrowIfDisposed();
 
                     var str = Dlib.Encoding.GetBytes(key ?? "");
+                    var strLength = str.Length;
+                    Array.Resize(ref str, strLength + 1);
+                    str[strLength] = (byte)'\0';
                     var native = this.Parent.NativePtr;
                     if (!NativeMethods.image_dataset_metadata_box_get_parts_get_value(native, str, out var p))
                         throw new KeyNotFoundException();
@@ -283,6 +289,9 @@ namespace DlibDotNet.ImageDatasetMetadata
                     this.Parent.ThrowIfDisposed();
 
                     var str = Dlib.Encoding.GetBytes(key ?? "");
+                    var strLength = str.Length;
+                    Array.Resize(ref str, strLength + 1);
+                    str[strLength] = (byte)'\0';
                     var native = this.Parent.NativePtr;
                     using (var pp = value.ToNative())
                         NativeMethods.image_dataset_metadata_box_get_parts_set_value(native, str, pp.NativePtr);

--- a/src/DlibDotNet/DataIO/ImageDatasetMetadata/Dataset.cs
+++ b/src/DlibDotNet/DataIO/ImageDatasetMetadata/Dataset.cs
@@ -36,6 +36,9 @@ namespace DlibDotNet.ImageDatasetMetadata
             {
                 this.ThrowIfDisposed();
                 var str = Dlib.Encoding.GetBytes(value ?? "");
+                var strLength = str.Length;
+                Array.Resize(ref str, strLength + 1);
+                str[strLength] = (byte)'\0';
                 NativeMethods.image_dataset_metadata_dataset_set_comment(this.NativePtr, str);
             }
         }
@@ -54,6 +57,9 @@ namespace DlibDotNet.ImageDatasetMetadata
             {
                 this.ThrowIfDisposed();
                 var str = Dlib.Encoding.GetBytes(value ?? "");
+                var strLength = str.Length;
+                Array.Resize(ref str, strLength + 1);
+                str[strLength] = (byte)'\0';
                 NativeMethods.image_dataset_metadata_dataset_set_name(this.NativePtr, str);
             }
         }

--- a/src/DlibDotNet/DataIO/ImageDatasetMetadata/Image.cs
+++ b/src/DlibDotNet/DataIO/ImageDatasetMetadata/Image.cs
@@ -26,6 +26,9 @@ namespace DlibDotNet.ImageDatasetMetadata
         public Image(string filename)
         {
             var str = Dlib.Encoding.GetBytes(filename);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             this.NativePtr = NativeMethods.image_dataset_metadata_image_new(str);
         }
 
@@ -69,6 +72,9 @@ namespace DlibDotNet.ImageDatasetMetadata
             {
                 this.ThrowIfDisposed();
                 var str = Dlib.Encoding.GetBytes(value ?? "");
+                var strLength = str.Length;
+                Array.Resize(ref str, strLength + 1);
+                str[strLength] = (byte)'\0';
                 NativeMethods.image_dataset_metadata_image_set_filename(this.NativePtr, str);
             }
         }

--- a/src/DlibDotNet/DataIO/ImageDatasetMetadata/ImageDatasetMetadata.cs
+++ b/src/DlibDotNet/DataIO/ImageDatasetMetadata/ImageDatasetMetadata.cs
@@ -23,6 +23,9 @@ namespace DlibDotNet
                     throw new FileNotFoundException($"{filename} is not found", filename);
 
                 var str = Encoding.GetBytes(filename);
+                var strLength = str.Length;
+                Array.Resize(ref str, strLength + 1);
+                str[strLength] = (byte)'\0';
 
                 var dataset = new Dataset();
                 var ret = NativeMethods.load_image_dataset_metadata(dataset.NativePtr, str);
@@ -42,6 +45,9 @@ namespace DlibDotNet
                 dataset.ThrowIfDisposed();
 
                 var str = Encoding.GetBytes(filename);
+                var strLength = str.Length;
+                Array.Resize(ref str, strLength + 1);
+                str[strLength] = (byte)'\0';
 
                 var ret = NativeMethods.save_image_dataset_metadata(dataset.NativePtr, str);
                 if (ret == NativeMethods.ErrorType.GeneralFileIOError)

--- a/src/DlibDotNet/DataIO/LoadImageDataset.cs
+++ b/src/DlibDotNet/DataIO/LoadImageDataset.cs
@@ -25,6 +25,9 @@ namespace DlibDotNet
                 throw new NotSupportedException();
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             images = new Array<Array2D<T>>();
             using (var retBoxes = new StdVector<StdVector<FullObjectDetection>>())
@@ -50,6 +53,9 @@ namespace DlibDotNet
                 throw new FileNotFoundException("", path);
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             using (var matrix = new Matrix<T>())
             using (var retImages = new StdVector<Matrix<T>>())
@@ -75,6 +81,9 @@ namespace DlibDotNet
                 throw new FileNotFoundException("", path);
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             using (var matrix = new Matrix<T>())
             using (var retImages = new StdVector<Matrix<T>>())

--- a/src/DlibDotNet/DataIO/MNIST.cs
+++ b/src/DlibDotNet/DataIO/MNIST.cs
@@ -28,6 +28,9 @@ namespace DlibDotNet
             testingLabels = null;
 
             var str = Encoding.GetBytes(folderPath);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             NativeMethods.load_mnist_dataset(str, 
                                              out var retTrainingImages,

--- a/src/DlibDotNet/Dlib.cs
+++ b/src/DlibDotNet/Dlib.cs
@@ -249,6 +249,9 @@ namespace DlibDotNet
                 throw new FileNotFoundException($"The specified {nameof(path)} does not exist.", path);
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var image = new Array2D<T>();
 
@@ -284,6 +287,9 @@ namespace DlibDotNet
                 throw new FileNotFoundException($"The specified {nameof(path)} does not exist.", path);
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var image = new Array2D<T>();
 
@@ -319,6 +325,9 @@ namespace DlibDotNet
                 throw new FileNotFoundException($"The specified {nameof(path)} does not exist.", path);
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var image = new Array2D<T>();
 
@@ -357,6 +366,9 @@ namespace DlibDotNet
                 throw new NotSupportedException($"{typeof(T).Name} does not support");
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var matrixElementType = type.ToNativeMatrixElementType();
             var ret = NativeMethods.load_image_matrix(matrixElementType, str, out var matrix, out var errorMessage);
@@ -390,6 +402,9 @@ namespace DlibDotNet
                 throw new FileNotFoundException($"The specified {nameof(path)} does not exist.", path);
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var image = new Array2D<T>();
 
@@ -425,6 +440,9 @@ namespace DlibDotNet
                 throw new FileNotFoundException($"The specified {nameof(path)} does not exist.", path);
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var image = new Array2D<T>();
 
@@ -650,6 +668,9 @@ namespace DlibDotNet
                 throw new ArgumentException($"{nameof(image.Columns)} and {nameof(image.Rows)} is less than or equal to zero.", nameof(image));
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var array2DType = image.ImageType.ToNativeArray2DType();
             var ret = NativeMethods.save_bmp(array2DType, image.NativePtr, str);
@@ -683,6 +704,9 @@ namespace DlibDotNet
                 throw new ArgumentException($"{nameof(matrix.Columns)} and {nameof(matrix.Rows)} is less than or equal to zero.", nameof(matrix));
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var matrixElementType = matrix.MatrixElementType.ToNativeMatrixElementType();
             var ret = NativeMethods.save_bmp_matrix(matrixElementType, matrix.NativePtr, matrix.TemplateRows, matrix.TemplateColumns, str);
@@ -719,6 +743,9 @@ namespace DlibDotNet
                 throw new ArgumentException($"{nameof(image.Columns)} and {nameof(image.Rows)} is less than or equal to zero.", nameof(image));
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var array2DType = image.ImageType.ToNativeArray2DType();
             var ret = NativeMethods.save_dng(array2DType, image.NativePtr, str);
@@ -752,6 +779,9 @@ namespace DlibDotNet
                 throw new ArgumentException($"{nameof(matrix.Columns)} and {nameof(matrix.Rows)} is less than or equal to zero.", nameof(matrix));
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var matrixElementType = matrix.MatrixElementType.ToNativeMatrixElementType();
             var ret = NativeMethods.save_dng_matrix(matrixElementType, matrix.NativePtr, matrix.TemplateRows, matrix.TemplateColumns, str);
@@ -792,6 +822,9 @@ namespace DlibDotNet
                 throw new ArgumentOutOfRangeException(nameof(quality), $"{nameof(quality)} is greater than 100.");
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var array2DType = image.ImageType.ToNativeArray2DType();
             var ret = NativeMethods.save_jpeg(array2DType, image.NativePtr, str, quality);
@@ -829,6 +862,9 @@ namespace DlibDotNet
                 throw new ArgumentOutOfRangeException(nameof(quality), $"{nameof(quality)} is greater than 100.");
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var matrixElementType = matrix.MatrixElementType.ToNativeMatrixElementType();
             var ret = NativeMethods.save_jpeg_matrix(matrixElementType, matrix.NativePtr, matrix.TemplateRows, matrix.TemplateColumns, str, quality);
@@ -863,6 +899,9 @@ namespace DlibDotNet
                 throw new ArgumentException($"{nameof(image.Columns)} and {nameof(image.Rows)} is less than or equal to zero.", nameof(image));
 
             var str = Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             var array2DType = image.ImageType.ToNativeArray2DType();
             var ret = NativeMethods.save_png(array2DType, image.NativePtr, str);

--- a/src/DlibDotNet/DlibDotNet.csproj
+++ b/src/DlibDotNet/DlibDotNet.csproj
@@ -1,5 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Takuya Takeuchi</Authors>
@@ -11,36 +10,29 @@
     <RepositoryUrl>https://github.com/takuya-takeuchi/DlibDotNet</RepositoryUrl>
     <PackageTags>dlib .net machinelearning</PackageTags>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
-  
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <FileUpgradeFlags>40</FileUpgradeFlags>
+    <UpgradeBackupLocation>C:\Development\DlibDotNet\Backup\src\DlibDotNet\</UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
-
-
   <!-- define $(PlatformId) and compile-time constants for NativeMethods.cs  -->
   <Import Project="RuntimeId.props" />
-
   <PropertyGroup>
-      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DefineConstants>$(DefineConstants);TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <Optimize>true</Optimize>
     <DocumentationFile>docs\DlibDotNet.xml</DocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="StdLib\Pair\**" />
     <EmbeddedResource Remove="StdLib\Pair\**" />
     <None Remove="StdLib\Pair\**" />
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="docs\" />
   </ItemGroup>
-
-
 </Project>

--- a/src/DlibDotNet/Dnn/DnnTrainer.cs
+++ b/src/DlibDotNet/Dnn/DnnTrainer.cs
@@ -339,6 +339,9 @@ namespace DlibDotNet.Dnn
             public override void SetSynchronizationFile(string filename, uint second = 900)
             {
                 var str = Dlib.Encoding.GetBytes(filename);
+                var strLength = str.Length;
+                Array.Resize(ref str, strLength + 1);
+                str[strLength] = (byte)'\0';
                 var ret = NativeMethods.dnn_trainer_loss_metric_set_synchronization_file(this.NativePtr, this.NetworkType, str, second);
                 if (ret == NativeMethods.ErrorType.DnnNotSupportNetworkType)
                     throw new NotSupportNetworkTypeException(this.NetworkType);
@@ -450,6 +453,9 @@ namespace DlibDotNet.Dnn
             public override void SetSynchronizationFile(string filename, uint second = 900)
             {
                 var str = Dlib.Encoding.GetBytes(filename);
+                var strLength = str.Length;
+                Array.Resize(ref str, strLength + 1);
+                str[strLength] = (byte)'\0';
                 var ret = NativeMethods.dnn_trainer_loss_mmod_set_synchronization_file(this.NativePtr, this.NetworkType, str, second);
                 if (ret == NativeMethods.ErrorType.DnnNotSupportNetworkType)
                     throw new NotSupportNetworkTypeException(this.NetworkType);
@@ -561,6 +567,9 @@ namespace DlibDotNet.Dnn
             public override void SetSynchronizationFile(string filename, uint second = 900)
             {
                 var str = Dlib.Encoding.GetBytes(filename);
+                var strLength = str.Length;
+                Array.Resize(ref str, strLength + 1);
+                str[strLength] = (byte)'\0';
                 var ret = NativeMethods.dnn_trainer_loss_multiclass_log_set_synchronization_file(this.NativePtr, this.NetworkType, str, second);
                 if (ret == NativeMethods.ErrorType.DnnNotSupportNetworkType)
                     throw new NotSupportNetworkTypeException(this.NetworkType);
@@ -672,6 +681,9 @@ namespace DlibDotNet.Dnn
             public override void SetSynchronizationFile(string filename, uint second = 900)
             {
                 var str = Dlib.Encoding.GetBytes(filename);
+                var strLength = str.Length;
+                Array.Resize(ref str, strLength + 1);
+                str[strLength] = (byte)'\0';
                 var ret = NativeMethods.dnn_trainer_loss_multiclass_log_per_pixel_set_synchronization_file(this.NativePtr, this.NetworkType, str, second);
                 if (ret == NativeMethods.ErrorType.DnnNotSupportNetworkType)
                     throw new NotSupportNetworkTypeException(this.NetworkType);

--- a/src/DlibDotNet/Dnn/LossMetric.cs
+++ b/src/DlibDotNet/Dnn/LossMetric.cs
@@ -82,6 +82,9 @@ namespace DlibDotNet.Dnn
                 throw new FileNotFoundException($"{path} is not found", path);
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var error = NativeMethods.loss_metric_deserialize(str,
                                                               networkType, 
                                                               out var net,
@@ -137,6 +140,9 @@ namespace DlibDotNet.Dnn
         internal override void NetToXml(string filename)
         {
             var fileNameByte = Dlib.Encoding.GetBytes(filename);
+            var strLength = fileNameByte.Length;
+            Array.Resize(ref fileNameByte, strLength + 1);
+            fileNameByte[strLength] = (byte)'\0';
             NativeMethods.loss_metric_net_to_xml(this.NativePtr, this.NetworkType, fileNameByte);
         }
 
@@ -200,6 +206,9 @@ namespace DlibDotNet.Dnn
             net.ThrowIfDisposed();
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var error= NativeMethods.loss_metric_serialize(net.NativePtr, net.NetworkType, str, out var errorMessage);
             switch (error)
             {

--- a/src/DlibDotNet/Dnn/LossMmod.cs
+++ b/src/DlibDotNet/Dnn/LossMmod.cs
@@ -104,6 +104,9 @@ namespace DlibDotNet.Dnn
                 throw new FileNotFoundException($"{path} is not found", path);
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var error = NativeMethods.loss_mmod_deserialize(str,
                                                             networkType,
                                                             out var net,
@@ -162,6 +165,9 @@ namespace DlibDotNet.Dnn
         internal override void NetToXml(string filename)
         {
             var fileNameByte = Dlib.Encoding.GetBytes(filename);
+            var strLength = fileNameByte.Length;
+            Array.Resize(ref fileNameByte, strLength + 1);
+            fileNameByte[strLength] = (byte)'\0';
             NativeMethods.loss_mmod_net_to_xml(this.NativePtr, this.NetworkType, fileNameByte);
         }
 
@@ -225,6 +231,9 @@ namespace DlibDotNet.Dnn
             net.ThrowIfDisposed();
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var error = NativeMethods.loss_mmod_serialize(net.NativePtr, net.NetworkType, str, out var errorMessage);
             switch (error)
             {

--- a/src/DlibDotNet/Dnn/LossMulticlassLog.cs
+++ b/src/DlibDotNet/Dnn/LossMulticlassLog.cs
@@ -83,6 +83,9 @@ namespace DlibDotNet.Dnn
                 throw new FileNotFoundException($"{path} is not found", path);
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var error = NativeMethods.loss_multiclass_log_deserialize(str,
                                                                       networkType,
                                                                       out var net,
@@ -138,6 +141,9 @@ namespace DlibDotNet.Dnn
         internal override void NetToXml(string filename)
         {
             var fileNameByte = Dlib.Encoding.GetBytes(filename);
+            var strLength = fileNameByte.Length;
+            Array.Resize(ref fileNameByte, strLength + 1);
+            fileNameByte[strLength] = (byte)'\0';
             NativeMethods.loss_multiclass_log_net_to_xml(this.NativePtr, this.NetworkType, fileNameByte);
         }
 
@@ -200,6 +206,9 @@ namespace DlibDotNet.Dnn
             net.ThrowIfDisposed();
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var error = NativeMethods.loss_multiclass_log_serialize(net.NativePtr, net.NetworkType, str, out var errorMessage);
             switch (error)
             {

--- a/src/DlibDotNet/Dnn/LossMulticlassLogPerPixel.cs
+++ b/src/DlibDotNet/Dnn/LossMulticlassLogPerPixel.cs
@@ -84,6 +84,9 @@ namespace DlibDotNet.Dnn
                 throw new FileNotFoundException($"{path} is not found", path);
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var error = NativeMethods.loss_multiclass_log_per_pixel_deserialize(str, 
                                                                                 networkType, 
                                                                                 out var net,
@@ -142,6 +145,9 @@ namespace DlibDotNet.Dnn
         internal override void NetToXml(string filename)
         {
             var fileNameByte = Dlib.Encoding.GetBytes(filename);
+            var strLength = fileNameByte.Length;
+            Array.Resize(ref fileNameByte, strLength + 1);
+            fileNameByte[strLength] = (byte)'\0';
             NativeMethods.loss_multiclass_log_per_pixel_net_to_xml(this.NativePtr, this.NetworkType, fileNameByte);
         }
 
@@ -205,6 +211,9 @@ namespace DlibDotNet.Dnn
             net.ThrowIfDisposed();
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var error = NativeMethods.loss_multiclass_log_per_pixel_serialize(net.NativePtr, net.NetworkType, str, out var errorMessage);
             switch (error)
             {

--- a/src/DlibDotNet/Dnn/MModOptions.cs
+++ b/src/DlibDotNet/Dnn/MModOptions.cs
@@ -197,6 +197,9 @@ namespace DlibDotNet.Dnn
                                          string label = null)
             {
                 var str = Dlib.Encoding.GetBytes(label ?? "");
+                var strLength = str.Length;
+                Array.Resize(ref str, strLength + 1);
+                str[strLength] = (byte)'\0';
                 this.NativePtr = NativeMethods.detector_window_details_new(width, height, str);
             }
 

--- a/src/DlibDotNet/GuiCore/BaseWindow.cs
+++ b/src/DlibDotNet/GuiCore/BaseWindow.cs
@@ -1,6 +1,9 @@
 ﻿
 
 // ReSharper disable once CheckNamespace
+
+using System;
+
 namespace DlibDotNet
 {
 
@@ -24,6 +27,9 @@ namespace DlibDotNet
             {
                 this.ThrowIfDisposed();
                 var title = Dlib.Encoding.GetBytes(value ?? "");
+                var strLength = title.Length;
+                Array.Resize(ref title, strLength + 1);
+                title[strLength] = (byte)'\0';
                 NativeMethods.base_window_set_title(this.NativePtr, title);
             }
         }

--- a/src/DlibDotNet/GuiWidgets/BaseWidgets/MenuItemText.cs
+++ b/src/DlibDotNet/GuiWidgets/BaseWidgets/MenuItemText.cs
@@ -31,6 +31,9 @@ namespace DlibDotNet
             mediator.ThrowIfDisposed();
 
             var s = Dlib.Encoding.GetBytes(str ?? "");
+            var strLength = s.Length;
+            Array.Resize(ref s, strLength + 1);
+            s[strLength] = (byte)'\0';
             this.NativePtr = NativeMethods.menu_item_text_new(s, mediator.NativePtr, hk);
         }
 

--- a/src/DlibDotNet/GuiWidgets/Dlib.cs
+++ b/src/DlibDotNet/GuiWidgets/Dlib.cs
@@ -12,7 +12,13 @@ namespace DlibDotNet
         public static void MessageBox(string title, string message)
         {
             var t = Encoding.GetBytes(title ?? "");
+            var strLength = t.Length;
+            Array.Resize(ref t, strLength + 1);
+            t[strLength] = (byte)'\0';
             var m = Encoding.GetBytes(message ?? "");
+            strLength = m.Length;
+            Array.Resize(ref m, strLength + 1);
+            m[strLength] = (byte)'\0';
             NativeMethods.message_box(t, m);
         }
 

--- a/src/DlibDotNet/GuiWidgets/Widgets/ImageDisplay.cs
+++ b/src/DlibDotNet/GuiWidgets/Widgets/ImageDisplay.cs
@@ -31,6 +31,9 @@ namespace DlibDotNet
                 throw new ArgumentNullException(nameof(name));
 
             var str = Dlib.Encoding.GetBytes(name);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             NativeMethods.image_display_add_labelable_part_name(this.NativePtr, str);
         }
 
@@ -128,6 +131,9 @@ namespace DlibDotNet
             this.ThrowIfDisposed();
 
             var labelStr = Dlib.Encoding.GetBytes(label ?? "");
+            var strLength = labelStr.Length;
+            Array.Resize(ref labelStr, strLength + 1);
+            labelStr[strLength] = (byte)'\0';
             NativeMethods.image_display_set_default_overlay_rect_label(this.NativePtr, labelStr);
         }
 
@@ -212,6 +218,9 @@ namespace DlibDotNet
                 {
                     this.ThrowIfDisposed();
                     var str = Dlib.Encoding.GetBytes(value ?? "");
+                    var strLength = str.Length;
+                    Array.Resize(ref str, strLength + 1);
+                    str[strLength] = (byte)'\0';
                     NativeMethods.image_display_overlay_rect_set_label(this.NativePtr, str);
                 }
             }
@@ -302,6 +311,9 @@ namespace DlibDotNet
                         this.Parent.ThrowIfDisposed();
 
                         var str = Dlib.Encoding.GetBytes(key ?? "");
+                        var strLength = str.Length;
+                        Array.Resize(ref str, strLength + 1);
+                        str[strLength] = (byte)'\0';
                         var native = this.Parent.NativePtr;
                         if (!NativeMethods.image_display_overlay_rect_get_parts_get_value(native, str, out var p))
                             throw new KeyNotFoundException();
@@ -311,8 +323,11 @@ namespace DlibDotNet
                     set
                     {
                         this.Parent.ThrowIfDisposed();
-
+                        
                         var str = Dlib.Encoding.GetBytes(key ?? "");
+                        var strLength = str.Length;
+                        Array.Resize(ref str, strLength + 1);
+                        str[strLength] = (byte)'\0';
                         var native = this.Parent.NativePtr;
                         using (var pp = value.ToNative())
                             NativeMethods.image_display_overlay_rect_get_parts_set_value(native, str, pp.NativePtr);

--- a/src/DlibDotNet/GuiWidgets/Widgets/ImageWindow.cs
+++ b/src/DlibDotNet/GuiWidgets/Widgets/ImageWindow.cs
@@ -36,6 +36,9 @@ namespace DlibDotNet
             image.ThrowIfDisposed(nameof(image));
 
             var str = Dlib.Encoding.GetBytes(title);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             this.NativePtr = NativeMethods.image_window_new_array2d2(image.ImageType.ToNativeArray2DType(), image.NativePtr, str);
         }
 
@@ -61,6 +64,9 @@ namespace DlibDotNet
 
             var type = matrix.MatrixElementType.ToNativeMatrixElementType();
             var str = Dlib.Encoding.GetBytes(title);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             this.NativePtr = NativeMethods.image_window_new_matrix2(type, matrix.NativePtr, str);
         }
 
@@ -101,6 +107,9 @@ namespace DlibDotNet
             matrix.ThrowIfDisposed(nameof(matrix));
 
             var str = Dlib.Encoding.GetBytes(title);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
 
             IntPtr ret;
             NativeMethods.ErrorType err;

--- a/src/DlibDotNet/GuiWidgets/Widgets/Label.cs
+++ b/src/DlibDotNet/GuiWidgets/Widgets/Label.cs
@@ -23,6 +23,9 @@ namespace DlibDotNet
         {
             this.ThrowIfDisposed();
             var str = Dlib.Encoding.GetBytes(name ?? "");
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             NativeMethods.label_set_text(this.NativePtr, str);
         }
 

--- a/src/DlibDotNet/GuiWidgets/Widgets/MenuBar.cs
+++ b/src/DlibDotNet/GuiWidgets/Widgets/MenuBar.cs
@@ -36,6 +36,9 @@ namespace DlibDotNet
         {
             this.ThrowIfDisposed();
             var str = Dlib.Encoding.GetBytes(name ?? "");
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             NativeMethods.menu_bar_set_menu_name(this.NativePtr, index, str, underline);
         }
 

--- a/src/DlibDotNet/GuiWidgets/Widgets/PerspectiveWindow.cs
+++ b/src/DlibDotNet/GuiWidgets/Widgets/PerspectiveWindow.cs
@@ -35,6 +35,9 @@ namespace DlibDotNet
             points.ThrowIfDisposed();
 
             var str = Dlib.Encoding.GetBytes(title);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             using (var vector = new StdVector<Vector<double>>(points))
                 this.NativePtr = NativeMethods.perspective_window_new3(vector.NativePtr, str);
         }

--- a/src/DlibDotNet/GuiWidgets/Widgets/TextField.cs
+++ b/src/DlibDotNet/GuiWidgets/Widgets/TextField.cs
@@ -47,6 +47,9 @@ namespace DlibDotNet
             {
                 this.ThrowIfDisposed();
                 var str = Dlib.Encoding.GetBytes(value ?? "");
+                var strLength = str.Length;
+                Array.Resize(ref str, strLength + 1);
+                str[strLength] = (byte)'\0';
                 NativeMethods.text_field_set_text(this.NativePtr, str);
             }
         }

--- a/src/DlibDotNet/ImageProcessing/ObjectDetector.cs
+++ b/src/DlibDotNet/ImageProcessing/ObjectDetector.cs
@@ -71,6 +71,9 @@ namespace DlibDotNet
             this.ThrowIfDisposed();
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             this._Imp.Deserialize(str);
         }
 
@@ -101,6 +104,9 @@ namespace DlibDotNet
             this.ThrowIfDisposed();
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             this._Imp.Serialize(str);
         }
 

--- a/src/DlibDotNet/ImageProcessing/ShapePredictor.cs
+++ b/src/DlibDotNet/ImageProcessing/ShapePredictor.cs
@@ -58,6 +58,9 @@ namespace DlibDotNet
                 throw new FileNotFoundException($"{path} is not found", path);
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1 );
+            str[strLength] = (byte)'\0';
             var ret = NativeMethods.deserialize_shape_predictor(str,
                                                                 out var predictor,
                                                                 out var errorMessage);
@@ -205,6 +208,9 @@ namespace DlibDotNet
             predictor.ThrowIfDisposed();
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var ret = NativeMethods.serialize_shape_predictor(predictor.NativePtr,
                                                               str,
                                                               out var errorMessage);

--- a/src/DlibDotNet/Logger/Logger.cs
+++ b/src/DlibDotNet/Logger/Logger.cs
@@ -12,6 +12,9 @@ namespace DlibDotNet
         public Logger(string name)
         {
             var nameByte = Dlib.Encoding.GetBytes(name ?? "");
+            var strLength = nameByte.Length;
+            Array.Resize(ref nameByte, strLength + 1);
+            nameByte[strLength] = (byte)'\0';
             this.NativePtr = NativeMethods.logger_new(nameByte);
         }
 
@@ -31,6 +34,9 @@ namespace DlibDotNet
             this.ThrowIfDisposed();
 
             var messageByte = Dlib.Encoding.GetBytes(message ?? "");
+            var strLength = messageByte.Length;
+            Array.Resize(ref messageByte, strLength + 1);
+            messageByte[strLength] = (byte)'\0';
             NativeMethods.logger_operator_left_shift(this.NativePtr, level, messageByte);
         }
 

--- a/src/DlibDotNet/ProxyDeserialize.cs
+++ b/src/DlibDotNet/ProxyDeserialize.cs
@@ -23,6 +23,9 @@ namespace DlibDotNet
                 throw new FileNotFoundException($"{path} is not found", path);
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             this.NativePtr = NativeMethods.proxy_deserialize_new(str);
         }
 

--- a/src/DlibDotNet/String/Dlib.cs
+++ b/src/DlibDotNet/String/Dlib.cs
@@ -1,4 +1,7 @@
 ﻿// ReSharper disable once CheckNamespace
+
+using System;
+
 namespace DlibDotNet
 {
 
@@ -10,6 +13,9 @@ namespace DlibDotNet
         public static string WrapString(string text, uint firstPad = 0, uint restPad = 0, uint maxPerLine = 79)
         {
             var str = Encoding.GetBytes(text ?? "");
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var ret = NativeMethods.wrap_string_char(str, firstPad, restPad, maxPerLine);
             return StringHelper.FromStdString(ret, true);
         }

--- a/src/DlibDotNet/SupportVectorMachine/DecisionFunction.cs
+++ b/src/DlibDotNet/SupportVectorMachine/DecisionFunction.cs
@@ -45,6 +45,9 @@ namespace DlibDotNet
             var param = new KernelBaseParameter(kernelType, sampleType, templateRows, templateColumns);
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var error = NativeMethods.deserialize_decision_function(str,
                                                                     kernelType.ToNativeKernelType(),
                                                                     sampleType.ToNativeMatrixElementType(),
@@ -78,6 +81,9 @@ namespace DlibDotNet
             function.ThrowIfDisposed();
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var ret = NativeMethods.serialize_decision_function(function._Parameter.KernelType.ToNativeKernelType(),
                                                                 function._Parameter.SampleType.ToNativeMatrixElementType(),
                                                                 function._Parameter.TemplateRows,

--- a/src/DlibDotNet/SupportVectorMachine/Krls.cs
+++ b/src/DlibDotNet/SupportVectorMachine/Krls.cs
@@ -120,6 +120,9 @@ namespace DlibDotNet
                 throw new FileNotFoundException($"{path} is not found", path);
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var error = NativeMethods.deserialize_krls(str,
                                                        krls.Parameter.KernelType.ToNativeKernelType(),
                                                        krls.Parameter.SampleType.ToNativeMatrixElementType(),
@@ -175,6 +178,9 @@ namespace DlibDotNet
             krls.ThrowIfDisposed();
 
             var str = Dlib.Encoding.GetBytes(path);
+            var strLength = str.Length;
+            Array.Resize(ref str, strLength + 1);
+            str[strLength] = (byte)'\0';
             var ret = NativeMethods.serialize_krls(krls._Parameter.KernelType.ToNativeKernelType(),
                                                    krls._Parameter.SampleType.ToNativeMatrixElementType(),
                                                    krls._Parameter.TemplateRows,


### PR DESCRIPTION
System.Text.Encoding.GetBytes doesn't return byte arrays that are null terminated (which are required for when you work with C++ code), which caused some issues when I tried using the lib for facial landmark detection. This PR should fix it.