### PR TITLE
Fix Format24bppRgb conversion override

### DIFF
--- a/src/DlibDotNet.Extensions/Extensions/BitmapExtensions.cs
+++ b/src/DlibDotNet.Extensions/Extensions/BitmapExtensions.cs
@@ -40,10 +40,7 @@ namespace DlibDotNet.Extensions
             };
             OptimumConvertImageInfos[PixelFormat.Format24bppRgb] = new[]
             {
-                new ConvertInfo<ImageTypes>{ Type = ImageTypes.RgbPixel, RgbReverse = true }
-            };
-            OptimumConvertImageInfos[PixelFormat.Format24bppRgb] = new[]
-            {
+                new ConvertInfo<ImageTypes>{ Type = ImageTypes.RgbPixel, RgbReverse = true },
                 new ConvertInfo<ImageTypes>{ Type = ImageTypes.BgrPixel, RgbReverse = false }
             };
             OptimumConvertImageInfos[PixelFormat.Format32bppArgb] = new[]


### PR DESCRIPTION
The `BitmapExtensions` class contains an `OptimumConvertImageInfos` dictionary for some image formats. In recent commits the `24bppRgb -> RgbPixel` convertion was overrided with the `24bppRgb -> BgrPixel` convertion.

This PR aims to fix this issue and merge both `ConvertInfo`