### PR TITLE
Support for raw data access for array2d.

### DIFF
--- a/src/DlibDotNet.Native/dlib/array2d/array2d.h
+++ b/src/DlibDotNet.Native/dlib/array2d/array2d.h
@@ -18,7 +18,7 @@ ret = new dlib::array2d<__TYPE__>();
 ret = new dlib::array2d<__TYPE__>(rows, cols);
 
 #define array2d_data_raw_template(__TYPE__, error, type, ...) \
-ret = &(((array2d<__TYPE__>*)array)->[0][0]);
+ret = (void*)((array2d<__TYPE__>*)array)->begin();
 
 #define array2d_delete_template(__TYPE__, error, type, ...) \
 delete ((dlib::array2d<__TYPE__>*)array);

--- a/src/DlibDotNet.Native/dlib/array2d/array2d.h
+++ b/src/DlibDotNet.Native/dlib/array2d/array2d.h
@@ -17,6 +17,9 @@ ret = new dlib::array2d<__TYPE__>();
 #define array2d_new1_template(__TYPE__, error, type, ...) \
 ret = new dlib::array2d<__TYPE__>(rows, cols);
 
+#define array2d_data_raw_template(__TYPE__, error, type, ...) \
+ret = &(((array2d<__TYPE__>*)array)->[0][0]);
+
 #define array2d_delete_template(__TYPE__, error, type, ...) \
 delete ((dlib::array2d<__TYPE__>*)array);
 
@@ -155,6 +158,19 @@ DLLEXPORT void* array2d_new1(array2d_type type, int rows, int cols)
                      array2d_new1_template,
                      rows,
                      cols,
+                     ret);
+
+    return ret;
+}
+
+DLLEXPORT void* array2d_data_raw(array2d_type type, void* array) {
+    int error = ERR_OK;
+    void* ret = nullptr;
+
+    array2d_template(type,
+                     error,
+                     array2d_data_raw_template,
+                     array,
                      ret);
 
     return ret;

--- a/src/DlibDotNet/Array2D/Array2D.cs
+++ b/src/DlibDotNet/Array2D/Array2D.cs
@@ -137,6 +137,15 @@ namespace DlibDotNet
             }
         }
 
+        public override IntPtr Data
+        {
+            get
+            {
+                this.ThrowIfDisposed();
+                return NativeMethods.array2d_data_raw(this._Array2DType, this.NativePtr);
+            }
+        }
+
         public Row<TElement> this[int row]
         {
             get

--- a/src/DlibDotNet/Array2D/Array2DBase.cs
+++ b/src/DlibDotNet/Array2D/Array2DBase.cs
@@ -24,6 +24,11 @@ namespace DlibDotNet
             get;
         }
 
+
+        public abstract System.IntPtr Data
+        {
+            get;
+        }
         public abstract int Size
         {
             get;

--- a/src/DlibDotNet/PInvoke/Array2D/Array.cs
+++ b/src/DlibDotNet/PInvoke/Array2D/Array.cs
@@ -32,6 +32,9 @@ namespace DlibDotNet
         public static extern bool array2d_size(Array2DType type, IntPtr array, out int ret);
 
         [DllImport(NativeLibrary, CallingConvention = CallingConvention)]
+        public static extern IntPtr array2d_data_raw(Array2DType type, IntPtr array);
+
+        [DllImport(NativeLibrary, CallingConvention = CallingConvention)]
         [return: MarshalAs(UnmanagedType.U1)]
         public static extern bool array2d_set_size(Array2DType type, IntPtr array, int rows, int cols);
 


### PR DESCRIPTION
This change adds support to get a pointer to array2d contents through the interop layer. 

That tackles two major issues: 
* Bad performance due to frequent memory copying
* Unsupported conversion, i.e. UInt8 to RGBA. 

Downside: 
If the array2d object does not have continuous memory (could happen with custom implementations of array2d), any use of the pointer will likely cause memory corruption. 

This is WIP - I still need to test it. But let me know what you think @takuya-takeuchi.